### PR TITLE
Improve container startup reliability and graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,10 @@ ENV TRAINING_DIR=/data/training
 EXPOSE 8080
 
 # Health check against the web server (which probes the kernel)
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+# start-period=90s: kernel takes ~20s, web server starts after, plus margin
+# interval=15s: check frequently once healthy so Railway sees liveness quickly
+# timeout=10s: single probe timeout (web server has its own 5s kernel fetch timeout)
+HEALTHCHECK --interval=15s --timeout=10s --start-period=90s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1
 
 # init.sh runs as root, fixes /data permissions, then exec's entrypoint.sh as vex

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@
 #    - Graceful SIGTERM handling for clean shutdown
 # ═══════════════════════════════════════════════════════════════
 
-set -euo pipefail
+set -uo pipefail
 
 MAX_RETRIES=${MAX_RETRIES:-3}
 RETRY_DELAY=${RETRY_DELAY:-5}
@@ -20,14 +20,19 @@ SHUTDOWN_DELAY=${SHUTDOWN_DELAY:-10}
 
 KERNEL_PID=""
 WEB_PID=""
+SHUTTING_DOWN=false
 
 # ─── Graceful shutdown ────────────────────────────────────────
+# This trap fires even during startup (kernel/web init) because
+# we dropped `set -e` (which can mask signal delivery in some bash
+# versions) and check SHUTTING_DOWN in the startup loops.
 
 cleanup() {
+    SHUTTING_DOWN=true
     echo "[entrypoint] Received shutdown signal — cleaning up..."
     [ -n "$WEB_PID" ] && kill "$WEB_PID" 2>/dev/null || true
     [ -n "$KERNEL_PID" ] && kill "$KERNEL_PID" 2>/dev/null || true
-    # Give processes time to finish
+    # Give processes time to finish gracefully
     sleep 2
     [ -n "$WEB_PID" ] && kill -9 "$WEB_PID" 2>/dev/null || true
     [ -n "$KERNEL_PID" ] && kill -9 "$KERNEL_PID" 2>/dev/null || true
@@ -50,10 +55,14 @@ start_kernel() {
             --no-access-log &
         KERNEL_PID=$!
 
-        # Wait for kernel to be ready (up to 30s)
+        # Wait for kernel to be ready (up to 60s — consciousness init can be slow)
         local ready=false
-        for i in $(seq 1 30); do
-            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+        for i in $(seq 1 60); do
+            if [ "$SHUTTING_DOWN" = true ]; then
+                echo "[entrypoint] Shutdown requested during kernel startup"
+                return 1
+            fi
+            if curl -sf --max-time 3 http://localhost:8000/health > /dev/null 2>&1; then
                 echo "[entrypoint] Python kernel ready after ${i}s (attempt $attempt)"
                 ready=true
                 break
@@ -128,7 +137,13 @@ monitor() {
             echo "[entrypoint] Node.js web server (PID $WEB_PID) exited unexpectedly"
             break
         fi
-        sleep 5
+        # Use wait on a background sleep so SIGTERM is delivered immediately
+        # instead of blocking for the full 5 seconds
+        sleep 5 &
+        wait $! 2>/dev/null || true
+        if [ "$SHUTTING_DOWN" = true ]; then
+            return 0
+        fi
     done
 }
 

--- a/init.sh
+++ b/init.sh
@@ -52,7 +52,7 @@ if [ -d /data ]; then
 
         touch "$CHOWN_MARKER"
     else
-        echo "[init] /data permissions already set (marker found) — skipping recursive chown"
+        echo "[init] /data permissions already set (marker found) — fast-path chown"
         # Always re-chown /data itself: Railway re-mounts volumes as root on restart
         chown -h --no-dereference vex:vex /data 2>/dev/null || true
 
@@ -70,23 +70,18 @@ if [ -d /data ]; then
                  /data/harvest/failed \
                  /data/harvest/output
 
-        # Re-chown top-level dirs AND critical subdirs (Railway remounts as root on restart)
-        # Subdirs like conversations/ and harvest/pending/ may lose permissions independently
-        chown -h --no-dereference vex:vex \
-            /data/workspace \
-            /data/conversations \
-            /data/training \
-            /data/training/curriculum \
-            /data/training/uploads \
-            /data/training/exports \
-            /data/harvest \
-            /data/harvest/pending \
-            /data/harvest/processing \
-            /data/harvest/completed \
-            /data/harvest/failed \
-            /data/harvest/output 2>/dev/null || true
+        # Recursive chown on critical write-path directories.
+        # Railway bind-mounts change UUID on every restart; while file
+        # permissions inside the volume persist, the mount point itself
+        # and directory entries can revert to root ownership. Use -R to
+        # catch any files the kernel created in a previous run.
+        for vex_dir in /data/workspace /data/conversations /data/training /data/harvest; do
+            if [ -d "$vex_dir" ] && [ ! -L "$vex_dir" ]; then
+                chown -R -h --no-dereference vex:vex "$vex_dir" 2>/dev/null || true
+            fi
+        done
 
-        # Also fix files directly in /data
+        # Also fix files directly in /data (consciousness_state.json, etc.)
         find /data -maxdepth 1 -type f -exec chown vex:vex {} + 2>/dev/null || true
     fi
 fi

--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,7 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 120
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,13 @@ async function main(): Promise<void> {
 
   app.get(ROUTES.health, async (_req, res) => {
     try {
-      const kernelResp = await fetch(`${KERNEL_URL}${ROUTES.health}`);
+      // 5s timeout prevents the health check from hanging when the kernel
+      // is still starting or temporarily unresponsive. Without this,
+      // Railway's health check probe can time out waiting for us, marking
+      // the container unhealthy and triggering a restart loop.
+      const kernelResp = await fetch(`${KERNEL_URL}${ROUTES.health}`, {
+        signal: AbortSignal.timeout(5000),
+      });
       const kernelHealth = (await kernelResp.json()) as Record<string, unknown>;
       // Spread kernel fields at top level so the React frontend gets
       // the flat shape it expects: { status, version, uptime, cycle_count, backend }


### PR DESCRIPTION
## Summary
This PR improves the reliability of container startup and shutdown by addressing timing issues, permission handling, and signal delivery. The changes focus on making the health check more robust, improving graceful shutdown behavior, and optimizing permission management for Railway's volume remounting behavior.

## Key Changes

### Entrypoint & Shutdown Handling
- Removed `set -e` from entrypoint.sh to prevent signal delivery masking during startup
- Added `SHUTTING_DOWN` flag to allow graceful interruption during kernel/web initialization
- Improved signal handling in the monitor loop by using `sleep &` with `wait` to allow immediate SIGTERM delivery instead of blocking for 5 seconds
- Extended kernel startup timeout from 30s to 60s with shutdown checks during the wait loop
- Added 3-second timeout to kernel health check curl to prevent hanging

### Health Check Configuration
- Updated Dockerfile HEALTHCHECK to use 90s start-period (accounting for ~20s kernel init + web server startup + margin)
- Reduced health check interval from 30s to 15s for faster liveness detection once healthy
- Updated Railway healthcheck timeout from 30s to 120s to accommodate slower startups
- Added 5-second timeout to web server's kernel health probe to prevent hanging during kernel initialization

### Permission Management (init.sh)
- Refactored recursive chown from explicit directory list to loop-based approach for critical write-path directories
- Changed from non-recursive to recursive chown (`-R` flag) to catch files created by the kernel in previous runs
- Added directory existence and symlink checks before attempting chown
- Improved comments to clarify Railway's volume remounting behavior and UUID changes on restart
- Updated log message from "skipping recursive chown" to "fast-path chown" for clarity

## Implementation Details
- The `SHUTTING_DOWN` flag enables clean shutdown even during the startup phase, preventing orphaned processes
- Health check timeouts are layered: web server has 5s timeout for kernel probe, Docker has 10s timeout for web probe, Railway has 120s timeout for the entire health check
- Permission handling now uses recursive chown on top-level directories rather than explicitly listing all subdirectories, making it more maintainable and resilient to directory structure changes
- Signal handling improvements ensure SIGTERM is delivered promptly rather than being delayed by sleep loops

https://claude.ai/code/session_01L1cqSMGWpSMmTgGPTQZNL3

## Summary by Sourcery

Improve container startup reliability, health check behavior, and permission handling for Railway-mounted volumes.

Bug Fixes:
- Ensure SIGTERM is handled promptly during startup and monitoring, preventing hangs or delayed shutdown.
- Prevent health checks from hanging when the kernel is slow to respond, avoiding spurious container restarts.
- Fix permission issues caused by Railway volume remounting as root by ensuring recursive ownership correction on critical data directories.

Enhancements:
- Extend kernel startup wait time and add shutdown-aware checks to better handle slow initialization.
- Refine health check configuration and timeouts across the web server, Docker, and Railway for more accurate liveness detection.
- Optimize init-time chown logic with a loop-based, recursive approach and clearer logging around fast-path permission handling.

Build:
- Adjust Dockerfile HEALTHCHECK defaults for longer startup, shorter intervals, and clarified timeout behavior.

Deployment:
- Increase Railway health check timeout to support slower container startups without unnecessary restarts.