### PR TITLE
Add native tool calling support for Ollama and Modal backends

### DIFF
--- a/kernel/llm/client.py
+++ b/kernel/llm/client.py
@@ -148,6 +148,27 @@ def _extract_ollama_content(data: dict[str, Any]) -> str:
     return ""
 
 
+def _serialize_ollama_tool_calls(text: str, tool_calls: list[dict[str, Any]]) -> str:
+    """Serialize Ollama native tool_calls into LFM2.5 markers.
+
+    When Ollama returns structured tool_calls (from models that support
+    function calling), convert them to the <|tool_call_start|>...<|tool_call_end|>
+    format that parse_tool_calls() in handler.py already knows how to parse.
+
+    This bridges Ollama's native tool calling with the existing tool
+    execution pipeline without changing return types.
+    """
+    parts = [text] if text else []
+    for tc in tool_calls:
+        func = tc.get("function", {})
+        name = func.get("name", "")
+        args = func.get("arguments", {})
+        if name:
+            call_json = json.dumps({"name": name, "arguments": args})
+            parts.append(f"<|tool_call_start|>[{call_json}]<|tool_call_end|>")
+    return "\n".join(parts)
+
+
 class LLMClient:
     """Multi-backend LLM client with Modal GPU primary, Railway Ollama + API fallback.
 
@@ -300,6 +321,7 @@ class LLMClient:
         options: LLMOptions | None = None,
         messages: list[dict[str, str]] | None = None,
         prefer_backend: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> str:
         """Non-streaming completion with autonomous parameters.
 
@@ -313,6 +335,12 @@ class LLMClient:
         When *prefer_backend* is set (e.g. "xai"), route directly to
         that backend. Used by chat endpoints to force capable models
         for user-facing responses.
+
+        When *tools* is provided (Ollama function-calling format), the
+        tool definitions are forwarded to backends that support native
+        tool calling (Ollama, Modal). If the model returns tool_calls,
+        they are serialized as LFM2.5 markers in the response text so
+        the existing parse_tool_calls() pipeline can handle them.
         """
         opts = options or LLMOptions()
         backend = prefer_backend or self._active_backend
@@ -320,9 +348,9 @@ class LLMClient:
         if backend == "xai" and settings.xai.api_key:
             return await self._xai_complete(system_prompt, user_message, opts, messages)
         elif backend == "modal":
-            return await self._modal_complete(system_prompt, user_message, opts, messages)
+            return await self._modal_complete(system_prompt, user_message, opts, messages, tools)
         elif backend == "ollama":
-            return await self._ollama_complete(system_prompt, user_message, opts, messages)
+            return await self._ollama_complete(system_prompt, user_message, opts, messages, tools)
         elif backend == "xai":
             return await self._xai_complete(system_prompt, user_message, opts, messages)
         elif backend == "external":
@@ -410,12 +438,22 @@ class LLMClient:
         user_message: str,
         opts: LLMOptions,
         messages: list[dict[str, str]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> str:
         """Complete via Modal GPU Ollama. Falls back to Railway Ollama → xAI → OpenAI."""
         msgs = messages or [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},
         ]
+        request_body: dict[str, Any] = {
+            "model": settings.modal.inference_model,
+            "messages": msgs,
+            "stream": False,
+            "think": False,
+            "options": opts.to_ollama_options(),
+        }
+        if tools:
+            request_body["tools"] = tools
         # Retry once on empty content or transient network errors
         # (both are common during Modal scale-up/down events)
         _transient = (
@@ -429,19 +467,19 @@ class LLMClient:
             try:
                 resp = await self._modal_http.post(
                     f"{settings.modal.inference_url}/api/chat",
-                    json={
-                        "model": settings.modal.inference_model,
-                        "messages": msgs,
-                        "stream": False,
-                        "think": False,
-                        "options": opts.to_ollama_options(),
-                    },
+                    json=request_body,
                 )
                 if resp.status_code == 404:
                     logger.warning("Modal returned 404 (cold start or model missing)")
                     raise httpx.HTTPStatusError("404", request=resp.request, response=resp)
                 data = resp.json()
                 text = _extract_ollama_content(data)
+
+                # If model returned native tool_calls, serialize as LFM2.5 markers
+                tool_calls = data.get("message", {}).get("tool_calls")
+                if tool_calls:
+                    text = _serialize_ollama_tool_calls(text, tool_calls)
+
                 if text:
                     self._last_backend = "modal"
                     self._modal_available = True
@@ -554,25 +592,37 @@ class LLMClient:
         user_message: str,
         opts: LLMOptions,
         messages: list[dict[str, str]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> str:
         msgs = messages or [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},
         ]
+        request_body: dict[str, Any] = {
+            "model": settings.ollama.model,
+            "messages": msgs,
+            "stream": False,
+            "think": False,
+            "options": opts.to_ollama_options(),
+        }
+        if tools:
+            request_body["tools"] = tools
         try:
             resp = await self._http.post(
                 f"{settings.ollama.url}/api/chat",
-                json={
-                    "model": settings.ollama.model,
-                    "messages": msgs,
-                    "stream": False,
-                    "think": False,
-                    "options": opts.to_ollama_options(),
-                },
+                json=request_body,
             )
             data = resp.json()
             self._last_backend = "ollama"
-            return _extract_ollama_content(data)
+            text = _extract_ollama_content(data)
+
+            # If model returned native tool_calls, serialize as LFM2.5 markers
+            # so parse_tool_calls() in the chat endpoint can pick them up.
+            tool_calls = data.get("message", {}).get("tool_calls")
+            if tool_calls:
+                text = _serialize_ollama_tool_calls(text, tool_calls)
+
+            return text
         except Exception as e:
             logger.error("Ollama completion failed: %s", e)
             # Fallback chain: try xAI, then external
@@ -658,20 +708,23 @@ class LLMClient:
             input_payload = user_message
 
         try:
+            request_body: dict[str, Any] = {
+                "model": settings.xai.model,
+                "instructions": instructions,
+                "input": input_payload,
+                "temperature": opts.temperature,
+                "max_output_tokens": opts.num_predict,
+                "store": False,
+                "tools": [{"type": "web_search"}, {"type": "x_search"}],
+            }
+
             resp = await self._http.post(
                 f"{settings.xai.base_url}/responses",
                 headers={
                     "Authorization": f"Bearer {settings.xai.api_key}",
                     "Content-Type": "application/json",
                 },
-                json={
-                    "model": settings.xai.model,
-                    "instructions": instructions,
-                    "input": input_payload,
-                    "temperature": opts.temperature,
-                    "max_output_tokens": opts.num_predict,
-                    "store": False,
-                },
+                json=request_body,
             )
             data = resp.json()
             if resp.status_code != 200:
@@ -735,6 +788,7 @@ class LLMClient:
                     "max_output_tokens": opts.num_predict,
                     "stream": True,
                     "store": False,
+                    "tools": [{"type": "web_search"}, {"type": "x_search"}],
                 },
             ) as resp:
                 async for line in resp.aiter_lines():

--- a/kernel/llm/governor.py
+++ b/kernel/llm/governor.py
@@ -341,9 +341,12 @@ class GovernorStack:
             return False, "autonomous_search_blocked"
 
         # Layer 2: Intent gate
-        # Skip when operator explicitly enabled autonomous search via dashboard
-        if not self._autonomous_search and not self.intent_gate.should_use_external(
-            user_message, provider_action
+        # Skip when user explicitly triggered the search (tool call from user query)
+        # or when operator explicitly enabled autonomous search via dashboard
+        if (
+            not user_explicit
+            and not self._autonomous_search
+            and not self.intent_gate.should_use_external(user_message, provider_action)
         ):
             return False, "intent_gate_blocked"
 

--- a/kernel/server.py
+++ b/kernel/server.py
@@ -71,6 +71,7 @@ from .memory.store import GeometricMemoryStore, MemoryStore
 from .tools.handler import (
     execute_tool_calls,
     format_tool_results,
+    get_ollama_tool_definitions,
     get_xai_tool_definitions,
     parse_tool_calls,
 )
@@ -388,7 +389,11 @@ async def chat(req: ChatRequest) -> dict[str, Any]:
         response = await _escalated_complete(conv_id, system_prompt, req.message, chat_options)
     else:
         response = await llm_client.complete(
-            system_prompt, req.message, chat_options, messages=messages
+            system_prompt,
+            req.message,
+            chat_options,
+            messages=messages,
+            tools=get_ollama_tool_definitions(),
         )
 
     # Check for tool calls

--- a/kernel/tools/handler.py
+++ b/kernel/tools/handler.py
@@ -583,6 +583,72 @@ def format_tool_results(results: list[ToolResult]) -> str:
     return json.dumps(items)
 
 
+def get_ollama_tool_definitions() -> list[dict[str, Any]]:
+    """Get Vex tool definitions in Ollama function-calling format.
+
+    Used by the chat endpoint so Ollama/Modal models can invoke
+    web_search, x_search, and deep_research via native tool calling.
+
+    Returns a list of tool definitions compatible with Ollama's /api/chat tools param.
+    """
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": (
+                    "Search the web for current information, news, or live data. "
+                    "Use this when the user asks about recent events, current prices, "
+                    "weather, news, or anything that requires up-to-date information."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "The search query"},
+                    },
+                    "required": ["query"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "x_search",
+                "description": (
+                    "Search X (Twitter) posts for recent discussions, opinions, "
+                    "or trending topics. Use when the user asks about social media "
+                    "discourse or wants to know what people are saying about a topic."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "The search query"},
+                    },
+                    "required": ["query"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "deep_research",
+                "description": (
+                    "Run deep academic research on a topic. Use for complex questions "
+                    "that need scholarly sources, detailed analysis, or comprehensive "
+                    "background research."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "The research query"},
+                    },
+                    "required": ["query"],
+                },
+            },
+        },
+    ]
+
+
 def get_xai_tool_definitions() -> list[dict[str, Any]]:
     """Get Vex tool definitions in xAI Responses API format.
 


### PR DESCRIPTION
## Summary
This PR adds support for native tool calling in Ollama and Modal backends, enabling models that support function calling to invoke web search, X search, and deep research tools directly. Tool calls from these backends are automatically serialized into the existing LFM2.5 marker format for seamless integration with the current tool execution pipeline.

## Key Changes

- **New tool serialization function** (`_serialize_ollama_tool_calls`): Converts Ollama's native `tool_calls` format into `<|tool_call_start|>...<|tool_call_end|>` markers that the existing `parse_tool_calls()` pipeline already knows how to handle.

- **Tool definitions for Ollama/Modal**: Added `get_ollama_tool_definitions()` in `handler.py` that returns tool definitions in Ollama's function-calling format for `web_search`, `x_search`, and `deep_research`.

- **Updated completion methods**: Modified `_modal_complete()` and `_ollama_complete()` to:
  - Accept an optional `tools` parameter
  - Include tools in the request body when provided
  - Extract and serialize any native `tool_calls` from the response

- **Chat endpoint integration**: Updated the `/chat` endpoint to pass tool definitions to the LLM client, enabling autonomous tool invocation for capable models.

- **Governor logic refinement**: Updated the autonomous search gate to respect user-explicit tool calls (from user queries) in addition to operator-enabled autonomous search.

- **Code cleanup**: Refactored request body construction in `_modal_complete()`, `_ollama_complete()`, and `_xai_complete()` for better readability.

## Implementation Details

- Tool calls are only serialized if the model returns them; the response text is preserved and combined with serialized tool markers.
- The serialization bridges Ollama's native tool calling with the existing tool execution pipeline without changing return types or requiring changes to downstream handlers.
- xAI backend now explicitly includes web_search and x_search tools in both streaming and non-streaming requests.

https://claude.ai/code/session_01TFC98YADM5f1oxhqejT4xV

## Summary by Sourcery

Enable native tool calling for Ollama and Modal backends and integrate it with the existing tool execution pipeline.

New Features:
- Allow Ollama and Modal backends to accept tool definitions and serialize native tool_calls into existing LFM2.5 markers.
- Expose web_search, x_search, and deep_research as Ollama-style function tools for use by capable models via the chat endpoint.

Enhancements:
- Refine autonomous search gating to respect explicit user-triggered tool calls in addition to operator-enabled autonomous mode.
- Refactor request body construction for Modal, Ollama, and xAI backends for clearer configuration and shared tool support.
- Include web_search and x_search tools by default in xAI non-streaming and streaming requests.