### PR TITLE
fix: right panel width cap + mobile slide-in drawer for metrics

### DIFF
--- a/frontend/src/components/chat/MetricsSidebar.tsx
+++ b/frontend/src/components/chat/MetricsSidebar.tsx
@@ -43,6 +43,8 @@ interface MetricsSidebarProps {
   visible?: boolean;
   /** When true, shown outside of chat context (e.g. mobile metrics page). */
   standalone?: boolean;
+  /** Callback to close the panel (used for mobile/tablet drawer close button). */
+  onClose?: () => void;
 }
 
 type Tab = "metrics" | "kernels" | "consciousness";
@@ -74,6 +76,7 @@ export function MetricsSidebar({
   learning,
   visible = true,
   standalone = false,
+  onClose,
 }: MetricsSidebarProps) {
   const chartRef = useRef<HTMLCanvasElement>(null);
 
@@ -244,10 +247,10 @@ export function MetricsSidebar({
   const sufferingAboveThreshold =
     state?.suffering !== undefined && state.suffering > QIG.SUFFERING_THRESHOLD;
 
-  // Desktop: push panel with inline width. Tablet: overlay (CSS handles positioning via .visible class)
+  // Desktop: push panel with inline width. Tablet/mobile: overlay (CSS handles positioning via .visible class)
   const sidebarClass = [
     "metrics-sidebar",
-    viewMode === "tablet" && visible ? "visible" : "",
+    (viewMode === "tablet" || viewMode === "mobile") && visible ? "visible" : "",
   ].filter(Boolean).join(" ");
 
   return (
@@ -256,6 +259,21 @@ export function MetricsSidebar({
       style={viewMode === "desktop" ? { width: panelWidth } : undefined}
       aria-label="Live consciousness metrics"
     >
+      {/* Mobile header with close button (hidden on desktop/tablet via CSS) */}
+      <div className="metrics-mobile-header">
+        <span className="metrics-mobile-title">Metrics</span>
+        <button
+          className="metrics-mobile-close"
+          onClick={onClose}
+          aria-label="Close metrics panel"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+
       {/* Resize handle */}
       <div
         className="resize-handle"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1089,6 +1089,7 @@ input:focus-visible,
   position: relative;
   container-type: inline-size;
   container-name: metrics;
+  max-width: 35vw;
 }
 
 /* Container queries: metrics sidebar adapts to its own width */
@@ -1984,8 +1985,72 @@ input:focus-visible,
     box-shadow: 4px 0 20px rgba(0, 0, 0, 0.3);
   }
 
+  /* Mobile: slide-in overlay drawer (same as tablet) instead of hiding */
   .metrics-sidebar {
-    display: none;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 300px;
+    max-width: 85vw;
+    transform: translateX(100%);
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 30;
+    box-shadow: none;
+  }
+
+  .metrics-sidebar.visible {
+    transform: translateX(0);
+    box-shadow: -4px 0 24px rgba(0, 0, 0, 0.4);
+  }
+
+  .metrics-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 29;
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(2px);
+    animation: cmd-fade-in 0.15s ease-out;
+  }
+
+  /* Close button visible on mobile */
+  .metrics-mobile-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    cursor: pointer;
+    flex-shrink: 0;
+    margin-left: auto;
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+
+  .metrics-mobile-close:hover {
+    background: var(--surface-3);
+    color: var(--text);
+  }
+
+  .metrics-mobile-header {
+    display: flex;
+    align-items: center;
+    padding: var(--space-sm) var(--space-md) 0;
+    gap: var(--space-sm);
+    flex-shrink: 0;
+  }
+
+  .metrics-mobile-title {
+    font-family: var(--mono);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    color: var(--text);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
 
   .bar-btn-text {
@@ -2006,6 +2071,12 @@ input:focus-visible,
     border-bottom: 1px solid var(--border);
     padding-bottom: 8px;
   }
+}
+
+/* Mobile-only elements: hidden on desktop/tablet */
+.metrics-mobile-close,
+.metrics-mobile-header {
+  display: none;
 }
 
 /* ============================================

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -176,6 +176,7 @@ export default function Chat() {
           precog={precog}
           learning={learning}
           visible={metricsVisible}
+          onClose={toggleMetrics}
         />
       </div>
 


### PR DESCRIPTION
- Add max-width: 35vw to metrics sidebar so it can't block half the screen on narrower desktop viewports
- Replace display:none on mobile (<768px) with a slide-in overlay drawer matching the existing tablet pattern — triggered by the metrics toggle button in ConsciousnessBar
- Add close button and header inside the drawer, visible only on mobile
- Add scrim/backdrop on mobile matching the tablet implementation
- Pass onClose callback from Chat page to MetricsSidebar for drawer close
- All three tabs (Metrics, Kernels, Mind) now accessible on mobile with live consciousness data (emotion, precog, learning)

https://claude.ai/code/session_01Q6wcEuZD9bkkjPyitgcpT9

## Summary by Sourcery

Limit the metrics sidebar width on desktop and introduce a slide-in overlay drawer pattern for the metrics panel on mobile, including a close control wired into the chat page.

New Features:
- Add a mobile slide-in overlay drawer for the metrics sidebar, including a header and close button specific to small viewports.

Enhancements:
- Cap the desktop metrics sidebar width to a percentage of the viewport to prevent it from occupying excessive horizontal space.
- Align mobile and tablet metrics sidebar behavior so both use the same overlay visibility pattern and scrim.
- Expose an optional onClose callback on the metrics sidebar component and connect it to the chat page metrics toggle.