### PR TITLE
Make Modal Ollama health check timeout configurable

### DIFF
--- a/kernel/llm/client.py
+++ b/kernel/llm/client.py
@@ -319,14 +319,21 @@ class LLMClient:
         except Exception as e:
             logger.warning("Modal warm-up failed (will retry on first request): %s", e)
 
-    async def check_modal_ollama(self) -> bool:
-        """Check if Modal Ollama inference endpoint is reachable."""
+    async def check_modal_ollama(self, timeout: float = 10.0) -> bool:
+        """Check if Modal Ollama inference endpoint is reachable.
+
+        Args:
+            timeout: HTTP timeout in seconds. Use a short timeout (default 10s)
+                during startup to avoid blocking the lifespan and causing
+                entrypoint health-check timeouts. Cold starts are handled
+                by ``_warm_up_modal()`` in the background.
+        """
         if not settings.modal.inference_enabled or not settings.modal.inference_url:
             return False
         try:
             resp = await self._modal_http.get(
                 f"{settings.modal.inference_url}/api/tags",
-                timeout=60.0,  # Allow warm containers; cold starts handled by _warm_up_modal
+                timeout=timeout,
             )
             self._modal_available = resp.status_code == 200
             if self._modal_available:


### PR DESCRIPTION
## Summary
Made the HTTP timeout for Modal Ollama endpoint health checks configurable to prevent blocking during application startup and entrypoint health-check timeouts.

## Key Changes
- Added `timeout` parameter to `check_modal_ollama()` method with a default value of 10 seconds
- Changed hardcoded 60-second timeout to use the configurable parameter
- Updated docstring to explain the timeout behavior and clarify that cold starts are handled asynchronously by `_warm_up_modal()`

## Implementation Details
The default 10-second timeout is short enough to avoid blocking the application lifespan during startup, while still allowing sufficient time for warm containers to respond. Cold container starts are handled separately by the background `_warm_up_modal()` task, so the health check doesn't need to wait for them.

https://claude.ai/code/session_01CvHNETvTfnhM3ktNUmYdsv

## Summary by Sourcery

Make the Modal Ollama health check HTTP timeout configurable to avoid long blocking during startup while still detecting endpoint availability.

New Features:
- Allow configuring the HTTP timeout for the Modal Ollama inference endpoint health check via a `timeout` parameter.

Enhancements:
- Document the behavior and recommended usage of the Modal Ollama health check timeout, clarifying that cold starts are handled asynchronously.