### PR TITLE
Refactor metrics sidebar mobile styles and fix z-index stacking

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -557,6 +557,8 @@ input:focus-visible,
   flex-shrink: 0;
   gap: var(--space-sm);
   min-height: 40px;
+  position: relative;
+  z-index: 31;
 }
 
 .bar-left,
@@ -1942,6 +1944,53 @@ input:focus-visible,
    RESPONSIVE
    ============================================ */
 
+/* Default: scrim and overlay close button hidden on desktop */
+.metrics-scrim {
+  display: none;
+}
+
+.metrics-mobile-close,
+.metrics-mobile-header {
+  display: none;
+}
+
+/* Close button / header base styles (visible on tablet + mobile via media queries) */
+.metrics-mobile-close {
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-left: auto;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.metrics-mobile-close:hover {
+  background: var(--surface-3);
+  color: var(--text);
+}
+
+.metrics-mobile-header {
+  align-items: center;
+  padding: var(--space-sm) var(--space-md) 0;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}
+
+.metrics-mobile-title {
+  font-family: var(--mono);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 /* Tablet: metrics sidebar as overlay drawer */
 @media (min-width: 768px) and (max-width: 1024px) {
   .metrics-sidebar {
@@ -1970,10 +2019,11 @@ input:focus-visible,
     backdrop-filter: blur(2px);
     animation: cmd-fade-in 0.15s ease-out;
   }
-}
 
-.metrics-scrim {
-  display: none;
+  .metrics-mobile-close,
+  .metrics-mobile-header {
+    display: flex;
+  }
 }
 
 @media (max-width: 768px) {
@@ -2014,43 +2064,9 @@ input:focus-visible,
     animation: cmd-fade-in 0.15s ease-out;
   }
 
-  /* Close button visible on mobile */
-  .metrics-mobile-close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    color: var(--text-secondary);
-    cursor: pointer;
-    flex-shrink: 0;
-    margin-left: auto;
-    transition: background 0.15s ease, color 0.15s ease;
-  }
-
-  .metrics-mobile-close:hover {
-    background: var(--surface-3);
-    color: var(--text);
-  }
-
+  .metrics-mobile-close,
   .metrics-mobile-header {
     display: flex;
-    align-items: center;
-    padding: var(--space-sm) var(--space-md) 0;
-    gap: var(--space-sm);
-    flex-shrink: 0;
-  }
-
-  .metrics-mobile-title {
-    font-family: var(--mono);
-    font-size: var(--text-sm);
-    font-weight: 700;
-    color: var(--text);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
   }
 
   .bar-btn-text {
@@ -2071,12 +2087,6 @@ input:focus-visible,
     border-bottom: 1px solid var(--border);
     padding-bottom: 8px;
   }
-}
-
-/* Mobile-only elements: hidden on desktop/tablet */
-.metrics-mobile-close,
-.metrics-mobile-header {
-  display: none;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary
This PR refactors the CSS for the metrics sidebar mobile/tablet UI by consolidating duplicate styles and fixing z-index stacking issues. The changes improve code maintainability by moving shared styles to a common location and ensuring proper layering of UI elements.

## Key Changes
- **Z-index fix**: Added `position: relative` and `z-index: 31` to the top navigation bar to ensure proper stacking context
- **Style consolidation**: Moved `.metrics-mobile-close`, `.metrics-mobile-header`, and `.metrics-mobile-title` base styles from media queries to a shared default section with `display: none`
- **Media query cleanup**: Updated tablet (`768px-1024px`) and mobile (`max-width: 768px`) media queries to only override the `display: flex` property, eliminating ~35 lines of duplicated style definitions
- **Improved organization**: Reorganized responsive styles section to follow a clearer pattern: defaults → tablet overrides → mobile overrides

## Implementation Details
- Base styles for mobile UI elements are now defined once in the responsive section with sensible defaults (hidden on desktop)
- Media queries now only need to toggle visibility, reducing maintenance burden and potential style inconsistencies
- The z-index adjustment ensures the navigation bar appears above other content without relying on source order

https://claude.ai/code/session_013p4SPZsLLE7fdS44r7g3qD

## Summary by Sourcery

Refine metrics sidebar responsive styling and stacking behavior for mobile and tablet views.

Enhancements:
- Adjust the top navigation bar positioning and z-index to fix stacking issues above overlay content.
- Centralize base styles for metrics mobile header, close button, and title, with media queries only toggling visibility for tablet and mobile.
- Clean up responsive CSS by hiding scrim and mobile controls by default on desktop and simplifying tablet and mobile media query overrides.