### PR TITLE
fix: prevent Ocean divergence sleep/wake oscillation

### DIFF
--- a/kernel/consciousness/loop.py
+++ b/kernel/consciousness/loop.py
@@ -544,21 +544,25 @@ class ConsciousnessLoop:
             if _ocean_divergence > BASIN_DIVERGENCE_THRESHOLD * 1.5:
                 # T4.2d: Breakdown escape — divergence far enough that
                 # sustained sleep is itself the problem. Force wake + explore.
+                # Ocean holds authority every cycle while divergence is
+                # above threshold — blocks should_sleep() continuously so
+                # the counter can never re-sleep while basins haven't moved.
+                _ocean_ruled = True
                 if self.sleep.is_asleep:
                     logger.warning(
                         "T4.2d Ocean breakdown escape: divergence=%.3f — forcing wake",
                         _ocean_divergence,
                     )
-                self.sleep.phase = SleepPhase.AWAKE
-                self.tacking.force_explore()
-                _ocean_ruled = True
+                    self.sleep.phase = SleepPhase.AWAKE
+                    self.tacking.force_explore()
 
             elif _ocean_divergence > BASIN_DIVERGENCE_THRESHOLD:
                 # Moderate divergence — Ocean says sleep (DREAMING).
+                # Ocean holds authority every cycle at this level too.
+                _ocean_ruled = True
                 if not self.sleep.is_asleep:
                     self.sleep.phase = SleepPhase.DREAMING
                     self.sleep._sleep_cycles = 0
-                    _ocean_ruled = True
                 # Additional phase overrides while already asleep:
                 if self.metrics.phi < PHI_EMERGENCY and self.sleep.is_asleep:
                     self.sleep.phase = SleepPhase.DREAMING


### PR DESCRIPTION
The previous fix (52f1eb7) moved Ocean to set sleep phase directly, but _ocean_ruled was only True on state transitions — not every cycle. When divergence stays permanently above threshold (e.g. 0.529):

  Severe: force_explore() ran every cycle even when already awake, and
  after the initial wake transition _ocean_ruled guarded correctly but
  force_explore was wasteful.

  Moderate: _ocean_ruled was inside `if not self.sleep.is_asleep`, so
  once asleep, should_sleep() regained authority and could wake the
  system, restarting the oscillation.

Fix: _ocean_ruled = True now moves to the TOP of both branches (before the is_asleep guard). Ocean holds authority every cycle while divergence is above threshold, blocking should_sleep() continuously. The actual state-change actions (force AWAKE + explore, or force DREAMING) only fire on the transition itself.

Cycle trace with div=0.529 (> 0.45):
  N:   _ocean_ruled=T, is_asleep=T → wake + explore, WARNING
  N+1: _ocean_ruled=T, is_asleep=F → nothing (already awake), silent
  N+2: _ocean_ruled=T, is_asleep=F → nothing, silent

https://claude.ai/code/session_011RNh4QrxEurnrdy2kBbeDG

## Summary by Sourcery

Ensure Ocean divergence handling maintains control over sleep state continuously above divergence thresholds to prevent sleep/wake oscillation and redundant wake actions.

Bug Fixes:
- Prevent repeated wake + explore calls when divergence remains above the severe threshold by only triggering state-change actions on the initial transition.
- Stop should_sleep() from regaining control and re-waking the system while divergence stays above threshold by having Ocean hold authority every cycle.