### PR TITLE
Development

### DIFF
--- a/kernel/config/settings.py
+++ b/kernel/config/settings.py
@@ -71,7 +71,7 @@ class GPUHarvestConfig:
 
     enabled: bool = os.environ.get("GPU_HARVEST_ENABLED", "false").lower() == "true"
     # Harvest model MUST match the active inference model.
-    # Primary: GLM-4.7-Flash (Modal GPU, 30B-A3B MoE).
+    # Primary: GLM-4.7-Flash (Modal GPU).
     # Ollama fallback uses LFM2.5-1.2B-Thinking (vex-brain base).
     # Override GPU_HARVEST_MODEL if deploying with a different backend.
     model_id: str = os.environ.get("GPU_HARVEST_MODEL", "zai-org/GLM-4.7-Flash")

--- a/kernel/coordizer_v2/__init__.py
+++ b/kernel/coordizer_v2/__init__.py
@@ -14,7 +14,7 @@ Quick start:
 
     # Build from LLM harvest
     c = CoordizerV2.from_harvest(
-        model_id="LiquidAI/LFM2.5-1.2B-Thinking",
+        model_id="zai-org/GLM-4.7-Flash",
         corpus_path="corpus.txt",
     )
 

--- a/kernel/coordizer_v2/coordizer.py
+++ b/kernel/coordizer_v2/coordizer.py
@@ -16,7 +16,7 @@ Key differences from v1:
 Usage:
     # From scratch (harvest → compress → validate)
     coordizer = CoordizerV2.from_harvest(
-        model_id="LiquidAI/LFM2.5-1.2B-Thinking",
+        model_id="zai-org/GLM-4.7-Flash",
         corpus_path="corpus.txt",
     )
 
@@ -61,7 +61,7 @@ from .geometry import (
     slerp,
     to_simplex,
 )
-from .harvest import HarvestConfig, Harvester
+from .harvest import DEFAULT_HARVEST_MODEL_ID, HarvestConfig, Harvester
 from .resonance_bank import ResonanceBank
 from .types import (
     BasinCoordinate,
@@ -117,7 +117,7 @@ class CoordizerV2:
     @classmethod
     def from_harvest(
         cls,
-        model_id: str = "LiquidAI/LFM2.5-1.2B-Thinking",
+        model_id: str = DEFAULT_HARVEST_MODEL_ID,
         corpus_path: str | None = None,
         corpus_texts: list[str] | None = None,
         output_dir: str = "./coordizer_data",

--- a/kernel/coordizer_v2/harvest.py
+++ b/kernel/coordizer_v2/harvest.py
@@ -40,6 +40,8 @@ from .geometry import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_HARVEST_MODEL_ID: str = "zai-org/GLM-4.7-Flash"
+
 
 @dataclass
 class HarvestConfig:
@@ -133,7 +135,7 @@ class Harvester:
 
     def harvest_transformers(
         self,
-        model_id: str = "LiquidAI/LFM2.5-1.2B-Thinking",
+        model_id: str = DEFAULT_HARVEST_MODEL_ID,
     ) -> HarvestResult:
         """Harvest using HuggingFace Transformers (direct model access).
 
@@ -153,7 +155,7 @@ class Harvester:
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         model = AutoModelForCausalLM.from_pretrained(
             model_id,
-            device_map=self.config.device if self.config.device != "cpu" else None,
+            device_map="auto" if self.config.device != "cpu" else None,
             torch_dtype=(torch.bfloat16 if self.config.device != "cpu" else torch.float32),
         )
         model.eval()
@@ -379,7 +381,7 @@ class Harvester:
 
 
 def harvest_model(
-    model_id: str = "LiquidAI/LFM2.5-1.2B-Thinking",
+    model_id: str = DEFAULT_HARVEST_MODEL_ID,
     corpus_path: str | None = None,
     corpus_texts: list[str] | None = None,
     output_dir: str = "./harvest_output",
@@ -401,7 +403,7 @@ def harvest_model(
 
 
 async def harvest_model_auto(
-    model_id: str = "LiquidAI/LFM2.5-1.2B-Thinking",
+    model_id: str = DEFAULT_HARVEST_MODEL_ID,
     corpus_path: str | None = None,
     corpus_texts: list[str] | None = None,
     output_dir: str = "./harvest_output",


### PR DESCRIPTION
## Summary by Sourcery

Update Coordizer v2 harvesting defaults to use the GLM-4.7-Flash model and improve GPU device mapping behavior.

Enhancements:
- Change the default harvest model ID across Coordizer v2 APIs to a shared GLM-4.7-Flash constant.
- Adjust Transformers loading to use automatic device mapping on non-CPU devices for better GPU utilization.

Documentation:
- Clarify configuration comments to reflect GLM-4.7-Flash as the primary GPU harvest model.