### PR TITLE
fix: register 12 training proxy routes in Express (404 root cause)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -261,6 +261,41 @@ async function main(): Promise<void> {
   });
   proxyPost(ROUTES.training_complete);
   proxyGet(ROUTES.training_modal_data);
+
+  // Training data archive (GET list, POST archive, DELETE permanent)
+  proxyGet(ROUTES.training_archive);
+  proxyPost(ROUTES.training_archive);
+  app.delete(ROUTES.training_archive, async (req: Request, res: Response) => {
+    try {
+      const resp = await fetch(`${KERNEL_URL}${ROUTES.training_archive}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(req.body),
+      });
+      const data = await resp.json();
+      res.status(resp.status).json(data);
+    } catch (err) {
+      res
+        .status(502)
+        .json({ error: `Kernel unreachable: ${(err as Error).message}` });
+    }
+  });
+  proxyPost(ROUTES.training_restore);
+
+  // Training cancel
+  proxyPost(ROUTES.training_cancel);
+
+  // Adapter lifecycle
+  proxyPost(ROUTES.training_archive_adapters);
+  proxyPost(ROUTES.training_rollback);
+  proxyPost(ROUTES.training_fresh_start);
+  proxyPost(ROUTES.training_fresh_start_llm);
+  proxyPost(ROUTES.training_fresh_start_kernels);
+
+  // Adapter archive restore
+  proxyGet(ROUTES.training_list_archives);
+  proxyPost(ROUTES.training_restore_archive);
+
   // Training sync needs a longer timeout — pushes all JSONL to Modal
   app.post(ROUTES.training_sync, async (req: Request, res: Response) => {
     try {


### PR DESCRIPTION
## Root Cause

Express proxies to FastAPI via explicit `proxyGet()`/`proxyPost()` calls.
Adding routes to `src/config/routes.ts` does nothing without registration
in `src/index.ts`. All new training endpoints were unreachable (404).

## Fix

Added 12 proxy registrations in `src/index.ts`:
- GET/POST/DELETE `/training/archive`
- POST `/training/restore`, `/training/cancel`
- POST `/training/archive-adapters`, `/training/rollback`
- POST `/training/fresh-start`, `/training/fresh-start-llm`, `/training/fresh-start-kernels`
- GET `/training/archives`, POST `/training/restore-archive`

## Test plan
- [ ] No 404s on Training page console
- [ ] Archive, Cancel, Fresh Start buttons call endpoints successfully
- [ ] Adapter Archives section loads (or shows "No adapter archives found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Expose existing training archive and adapter lifecycle FastAPI endpoints through Express by adding the corresponding proxy routes, resolving prior 404 responses from the Training page.