### PR TITLE
fix: PEFT health check availability gating

### DIFF
--- a/kernel/llm/peft_client.py
+++ b/kernel/llm/peft_client.py
@@ -1,7 +1,7 @@
 """PEFT adapter inference client — Tier 2 in the Vex inference hierarchy.
 
 Calls the Modal QLoRA trainer's /infer endpoint which serves per-kernel
-adapters on Qwen3.5-4B via PEFT multi-adapter loading.
+adapters on Qwen3.5-35B-A3B via PEFT multi-adapter loading.
 
 Tier hierarchy:
   Tier 1: vLLM with native LoRA serving (production target — NOT YET BUILT)
@@ -87,11 +87,12 @@ class PeftInferenceClient:
         api_key: str = "",
     ) -> None:
         self._base_url = base_url.rstrip("/")
-        self._infer_url = f"{self._base_url}"
+        self._infer_url = self._base_url
         self._api_key = api_key
         self._available = False
         self._last_check: float = 0.0
-        self._check_interval = 60.0  # Re-check health every 60s
+        self._check_interval = 60.0  # Re-check health every 60s when healthy
+        self._retry_interval = 15.0  # Re-check every 15s when unavailable
 
         self._http = httpx.AsyncClient(
             timeout=httpx.Timeout(
@@ -115,23 +116,45 @@ class PeftInferenceClient:
             resp = await self._http.get(health_url)
             if resp.status_code == 200:
                 data = resp.json()
-                self._available = data.get("status") == "healthy"
+                status = data.get("status")
+                self._available = status == "healthy"
                 if self._available:
                     logger.info(
                         "PEFT inference healthy: specializations=%s",
                         data.get("specializations", []),
                     )
+                else:
+                    logger.warning(
+                        "PEFT health check returned status=%r (expected 'healthy'), url=%s",
+                        status,
+                        health_url,
+                    )
                 return self._available
+            else:
+                logger.warning(
+                    "PEFT health check HTTP %d from %s",
+                    resp.status_code,
+                    health_url,
+                )
+                self._available = False
         except Exception as e:
             logger.debug("PEFT health check failed: %s", e)
             self._available = False
         return False
 
     async def _ensure_available(self) -> bool:
-        """Lazy health check with caching."""
+        """Lazy health check with caching.
+
+        When PEFT is available, re-checks every _check_interval seconds.
+        When PEFT is unavailable, re-checks every _retry_interval seconds
+        (shorter to detect recovery quickly without hammering the endpoint).
+        """
         now = time.monotonic()
-        if now - self._last_check < self._check_interval and self._available:
+        elapsed = now - self._last_check
+        if self._available and elapsed < self._check_interval:
             return True
+        if not self._available and elapsed < self._retry_interval:
+            return False
         self._last_check = now
         return await self.check_health()
 
@@ -161,6 +184,15 @@ class PeftInferenceClient:
         Returns:
             PeftInferenceResult with generated text and metadata.
         """
+        if not await self._ensure_available():
+            return PeftInferenceResult(
+                text="",
+                specialization=specialization,
+                adapter_loaded="",
+                success=False,
+                error="PEFT endpoint unavailable (health check failed)",
+            )
+
         adapter = _KERNEL_TO_ADAPTER.get(specialization, "genesis")
 
         request_body: dict[str, Any] = {

--- a/kernel/tests/test_peft_health.py
+++ b/kernel/tests/test_peft_health.py
@@ -1,0 +1,171 @@
+"""Tests for PEFT health check and availability gating in peft_client.py."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kernel.llm.peft_client import PeftInferenceClient
+
+
+def _make_client(base_url: str = "https://example--app-web.modal.run/infer") -> PeftInferenceClient:
+    return PeftInferenceClient(base_url=base_url, timeout_ms=5000, api_key="test-key")
+
+
+class TestHealthCheck:
+    """Tests for check_health() status matching."""
+
+    def test_healthy_status_accepted(self) -> None:
+        client = _make_client()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"status": "healthy", "specializations": ["genesis"]}
+
+        async def _run():
+            client._http = AsyncMock()
+            client._http.get = AsyncMock(return_value=mock_resp)
+            result = await client.check_health()
+            assert result is True
+            assert client.available is True
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_ok_status_rejected(self) -> None:
+        """The old bug: Modal returned 'ok', client expected 'healthy'."""
+        client = _make_client()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"status": "ok"}
+
+        async def _run():
+            client._http = AsyncMock()
+            client._http.get = AsyncMock(return_value=mock_resp)
+            result = await client.check_health()
+            assert result is False
+            assert client.available is False
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_non_200_marks_unavailable(self) -> None:
+        client = _make_client()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+
+        async def _run():
+            client._http = AsyncMock()
+            client._http.get = AsyncMock(return_value=mock_resp)
+            result = await client.check_health()
+            assert result is False
+            assert client.available is False
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_connection_error_marks_unavailable(self) -> None:
+        import httpx
+
+        client = _make_client()
+
+        async def _run():
+            client._http = AsyncMock()
+            client._http.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+            result = await client.check_health()
+            assert result is False
+            assert client.available is False
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+
+class TestEnsureAvailable:
+    """Tests for _ensure_available() caching and retry logic."""
+
+    def test_caches_healthy_result(self) -> None:
+        client = _make_client()
+        client._available = True
+        client._last_check = time.monotonic()
+
+        async def _run():
+            result = await client._ensure_available()
+            assert result is True
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_caches_unhealthy_within_retry_interval(self) -> None:
+        client = _make_client()
+        client._available = False
+        client._last_check = time.monotonic()
+
+        async def _run():
+            result = await client._ensure_available()
+            assert result is False
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_rechecks_after_retry_interval(self) -> None:
+        client = _make_client()
+        client._available = False
+        client._last_check = time.monotonic() - 20.0  # Past the 15s retry interval
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"status": "healthy", "specializations": []}
+
+        async def _run():
+            client._http = AsyncMock()
+            client._http.get = AsyncMock(return_value=mock_resp)
+            result = await client._ensure_available()
+            assert result is True
+            assert client.available is True
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+
+class TestCompleteAvailabilityGate:
+    """Tests that complete() checks availability before hitting the endpoint."""
+
+    def test_skips_inference_when_unavailable(self) -> None:
+        client = _make_client()
+        client._available = False
+        client._last_check = time.monotonic()
+
+        async def _run():
+            result = await client.complete(
+                system_prompt="test",
+                user_message="hello",
+                specialization="genesis",
+            )
+            assert result.success is False
+            assert "unavailable" in result.error
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_proceeds_when_available(self) -> None:
+        client = _make_client()
+        client._available = True
+        client._last_check = time.monotonic()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "text": "response text",
+            "specialization": "genesis",
+            "adapter_loaded": "genesis",
+            "inference_tier": 2,
+            "tokens_generated": 10,
+            "latency_ms": 50.0,
+        }
+
+        async def _run():
+            client._http = AsyncMock()
+            client._http.post = AsyncMock(return_value=mock_resp)
+            result = await client.complete(
+                system_prompt="test",
+                user_message="hello",
+                specialization="genesis",
+            )
+            assert result.success is True
+            assert result.text == "response text"
+
+        asyncio.get_event_loop().run_until_complete(_run())

--- a/modal/vex_qlora_train.py
+++ b/modal/vex_qlora_train.py
@@ -276,6 +276,7 @@ KERNEL_CALLBACK_URL = os.environ.get("KERNEL_CALLBACK_URL", "")
 TRUSTED_MODEL_IDS: frozenset[str] = frozenset(
     {
         "Qwen/Qwen3.5-4B",
+        "Qwen/Qwen3.5-32B",
         "Qwen/Qwen3.5-35B-A3B",
     }
 )
@@ -285,7 +286,11 @@ TRAIN_GPU = os.environ.get("TRAIN_GPU", "a100-80gb")
 # TRAIN_GPU is evaluated at deploy time from local env, NOT from Modal secrets.
 # Always set TRAIN_GPU locally before `modal deploy`:
 #   TRAIN_GPU=a100-80gb modal deploy modal/vex_qlora_train.py
-_MODEL_GPU_FLOOR = {"Qwen/Qwen3.5-35B-A3B": "a100", "Qwen/Qwen3.5-4B": "a10g"}
+_MODEL_GPU_FLOOR = {
+    "Qwen/Qwen3.5-35B-A3B": "a100",
+    "Qwen/Qwen3.5-32B": "a100",
+    "Qwen/Qwen3.5-4B": "a10g",
+}
 _GPU_VRAM_ORDER = ["t4", "l4", "a10g", "a100", "a100-80gb", "h100"]
 _floor = _MODEL_GPU_FLOOR.get(HARVEST_MODEL_ID, "a10g")
 if (


### PR DESCRIPTION
## Summary
- **Activate `_ensure_available()` in `complete()`** — this method was defined but never called, meaning PEFT availability was only checked at startup. Now every inference call uses a cached health check (60s TTL when healthy, 15s retry when unavailable) to skip known-dead endpoints quickly and detect recovery automatically.
- **Improve health check diagnostic logging** — when the health endpoint returns a non-"healthy" status (e.g. the old `"ok"` bug) or a non-200 HTTP response, the actual value is now logged at WARNING level instead of being silently swallowed.
- **Add Qwen3.5-32B to TRUSTED_MODEL_IDS and GPU floor map** — supports the model upgrade from 4B to 32B per deployment env vars.

## Test plan
- [x] 9 new unit tests covering health check status matching, availability caching, retry intervals, and the complete() availability gate
- [x] All 88 existing modal_url tests pass
- [ ] Deploy to Railway and verify PEFT health check logs show `status='healthy'` on startup
- [ ] Verify fallback chain activates quickly (within 15s) when PEFT endpoint is unavailable

https://claude.ai/code/session_014mUdDUAszYqES8J9eUgrug

## Summary by Sourcery

Gate PEFT completions on a cached health check and extend model configuration for upgraded Qwen deployments.

Bug Fixes:
- Ensure each PEFT inference call checks cached health and short-interval retries before sending requests to an unavailable endpoint.
- Log non-healthy status values and non-200 HTTP responses from the PEFT health endpoint at warning level instead of silently failing.

Enhancements:
- Adjust PEFT health check caching to use different intervals for healthy versus unavailable states to balance responsiveness and load.
- Update PEFT client documentation and model description to reflect Qwen3.5-35B-A3B usage.

Deployment:
- Add Qwen3.5-32B to the trusted model list and GPU floor mapping for deployment configuration.

Tests:
- Add unit tests covering PEFT health status handling, availability caching and retry behavior, and the completion-time availability gate.